### PR TITLE
Add docs index with links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Fake SNS Screens</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    ul { list-style: none; padding: 0; }
+    li { margin: 0.5rem 0; }
+  </style>
+</head>
+<body>
+  <h1>Fake SNS Screens</h1>
+  <ul>
+    <li><a href="note_mock_generator.html">note mock generator</a></li>
+    <li><a href="spotify_episode_mock_generator.html">Spotify episode mock generator</a></li>
+    <li><a href="tweet_mock_generator_light.html">Tweet mock generator (light)</a></li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple `docs/index.html` with links to existing mock generator pages

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897f068c140832bb5c36ed8ad9d0906