### PR TITLE
feat: add viewport meta tag for mobile support

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>fake-sns-screen</title>
   <style>
     body { font-family: sans-serif; margin: 2rem; }

--- a/pages/note_list_generator.html
+++ b/pages/note_list_generator.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>note記事一覧モックジェネレータ</title>
 <style>
   body {

--- a/pages/note_mock_generator.html
+++ b/pages/note_mock_generator.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>note.com風記事モックジェネレータ</title>
 <style>
   body {

--- a/pages/spotify_episode_mock_generator.html
+++ b/pages/spotify_episode_mock_generator.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Spotify風ポッドキャストエピソードモックジェネレータ</title>
 <style>
   /* Base styling (dark mode) */

--- a/pages/tweet_mock_generator_light.html
+++ b/pages/tweet_mock_generator_light.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>ツイートモックジェネレータ（ライトモード）</title>
 <style>
   /* Base styling for light mode */


### PR DESCRIPTION
## Summary
- add viewport meta tag to all HTML pages for mobile responsiveness

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b757318d9c832bad490caed2351f27